### PR TITLE
Add a function to remove a node from the DOM

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -8,6 +8,10 @@ export function prependChild(node, container) {
 	container.insertBefore(node, container.firstChild);
 }
 
+export function removeNode(node) {
+	node.parentNode.removeChild(node);
+}
+
 export function replaceNode(oldNode, ...newNodes) {
 	let container = oldNode.parentNode;
 	newNodes.forEach(node => {


### PR DESCRIPTION
Removing a node from the DOM is quite awkward with the native DOM API. Imagine you want to remove the parent of `this` from the DOM, you have to write:

```js
this.parentNode.parentNode.removeChild(this.parentNode)
```

This is hard to parse. Instead I want to be able to write:

```js
removeChild(this.parentNode)
```

I think this fits the philosophy of this project 😄 